### PR TITLE
Add macOS support to FaultOrdering package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FaultOrdering",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v17), .macOS(.v13)],
     products: [
         .library(name: "FaultOrdering", type: .dynamic, targets: ["FaultOrdering"]),
         .library(name: "FaultOrderingTests", targets: ["FaultOrderingTests"]),

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FaultOrdering",
-    platforms: [.iOS(.v17), .macOS(.v13)],
+    platforms: [.iOS(.v16)],
     products: [
         .library(name: "FaultOrdering", type: .dynamic, targets: ["FaultOrdering"]),
         .library(name: "FaultOrderingTests", targets: ["FaultOrderingTests"]),

--- a/Sources/EMGFaultOrdering/EMGObjCHelper.m
+++ b/Sources/EMGFaultOrdering/EMGObjCHelper.m
@@ -5,7 +5,11 @@
 //  Created by Noah Martin on 5/17/25.
 //
 
+#if TARGET_OS_IOS
 @import UIKit;
+#elif TARGET_OS_OSX
+@import AppKit;
+#endif
 @import FaultOrderingSwift;
 
 #import "EMGObjCHelper.h"
@@ -13,7 +17,7 @@
 @implementation EMGObjCHelper
 
 + (NSObject*)startServerWithCallback:(NSData* (^)())callback {
-  return [[EMGServer alloc] initWithCallback:callback];
+    return [[EMGServer alloc] initWithCallback:callback];
 }
 
 @end

--- a/Sources/FaultOrderingTests/FaultOrderingTest.swift
+++ b/Sources/FaultOrderingTests/FaultOrderingTest.swift
@@ -50,7 +50,7 @@ public class FaultOrderingTest {
   private func getUsedAddresses(app: XCUIApplication, addresses: [Int]) -> Result {
     let data = try! JSONEncoder().encode(addresses)
     // Make the linkmap available to the app
-    let s = Server(callback: { return data })
+      _ = Server(callback: { return data })
 
     // Launch the app for setup
     var launchEnvironment = app.launchEnvironment

--- a/Sources/FaultOrderingTests/Linkmap.swift
+++ b/Sources/FaultOrderingTests/Linkmap.swift
@@ -77,7 +77,7 @@ func getLinkmap() throws -> [Int: Symbol] {
           continue
       }
       
-      var components = line.split(separator: "\t", maxSplits: 2).map(String.init)
+        let components = line.split(separator: "\t", maxSplits: 2).map(String.init)
       guard components.count == 3 else {
           continue
       }
@@ -107,7 +107,7 @@ func getLinkmap() throws -> [Int: Symbol] {
       }
     } else if inSections {
       if line.contains("__TEXT\t__text") {
-        var components = line.split(separator: "\t", maxSplits: 2).map(String.init)
+          let components = line.split(separator: "\t", maxSplits: 2).map(String.init)
         guard components.count == 3 else {
           continue
         }
@@ -115,10 +115,10 @@ func getLinkmap() throws -> [Int: Symbol] {
         textSectionSize = UInt64(components[1].dropFirst(2), radix: 16) ?? 0
       }
     } else if inObjectFiles {
-      if let bracketIndex = line.index(of: "]") {
+        if let bracketIndex = line.firstIndex(of: "]") {
         let line = line[line.index(bracketIndex, offsetBy: 2)...]
         if let match = try? /^(.*?)(?:\((.*)\))?$/.firstMatch(in: line) {
-          if let file = match.2.map { String($0) } {
+            if let file = match.2.map({ String($0) }) {
             objects.append(ObjectFile(file: file, library: String(match.1)))
           } else {
             objects.append(ObjectFile(file: String(match.1), library: nil))


### PR DESCRIPTION
Hi there! I'm pretty excited to see this project open sourced. I wanted to see if it also worked to generate order files for macOS targets as that's mostly what I work with. It was easy to add the support, and the demo app generates the expected files with the UI Tests.

Because robots can do work for us now I had Copilot generate a description of all the details below:

This pull request introduces platform support for macOS in the `FaultOrdering` package, improves compatibility for Objective-C helpers, and refines code readability and correctness in test-related files. Below is a breakdown of the most important changes grouped by theme:

### Platform Support:
* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL6-R6): Added macOS support (`.macOS(.v13)`) to the `platforms` section of the package definition. This expands the package's compatibility to macOS alongside iOS.

### Compatibility Enhancements:
* [`Sources/EMGFaultOrdering/EMGObjCHelper.m`](diffhunk://#diff-8b921d259f2f1681f0edd3ef8d4b6a71ccc11f433f82455ef8b6b142edeb7d6cR8-R12): Added conditional imports for `UIKit` (iOS) and `AppKit` (macOS) based on the target platform, ensuring compatibility with both operating systems.

### Code Refinements:
* [`Sources/FaultOrderingTests/FaultOrderingTest.swift`](diffhunk://#diff-208623f6e49af534a889efd1ba0699131f919b7ae3b9e1045d3c680d1a816ecfL53-R53): Replaced the unused variable `s` with `_` when initializing the `Server` object, adhering to Swift conventions for unused variables.
* [`Sources/FaultOrderingTests/Linkmap.swift`](diffhunk://#diff-cd2ffdad794c99ced5927db0c4ae1d8ddc3ffcbe317326e0b8f44d614ad81c12L80-R80): Replaced `var` with `let` for `components` in multiple locations to ensure immutability and improve code clarity. [[1]](diffhunk://#diff-cd2ffdad794c99ced5927db0c4ae1d8ddc3ffcbe317326e0b8f44d614ad81c12L80-R80) [[2]](diffhunk://#diff-cd2ffdad794c99ced5927db0c4ae1d8ddc3ffcbe317326e0b8f44d614ad81c12L110-R121)
* [`Sources/FaultOrderingTests/Linkmap.swift`](diffhunk://#diff-cd2ffdad794c99ced5927db0c4ae1d8ddc3ffcbe317326e0b8f44d614ad81c12L110-R121): Updated usage of `index(of:)` to `firstIndex(of:)` for better Swift API consistency and readability.