### PR TITLE
Lower minimum iOS version from 17.0 to 16.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FaultOrdering",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v16)],
     products: [
         .library(name: "FaultOrdering", type: .dynamic, targets: ["FaultOrdering"]),
         .library(name: "FaultOrderingTests", targets: ["FaultOrderingTests"]),


### PR DESCRIPTION
## Description
Fixes the unnecessarily restrictive iOS 17 minimum version requirement.

## Changes
- Updated `Package.swift` to support iOS 16.0 instead of 17.0

## Testing
✅ Verified full functionality on iOS 16 devices
✅ All dependencies support iOS 16 (FlyingFox supports iOS 13+)
✅ No iOS 17-specific APIs found in codebase

## Impact
- Expands compatibility to iOS 16 users
- No breaking changes

Fixes [#ISSUE_13](https://github.com/getsentry/FaultOrdering/issues/13)